### PR TITLE
Add optional Material GNOME Manager app mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ ln -sf ~/.themes/Material-Gnome/gtk-4.0/gtk.css ~/.config/gtk-4.0/gtk.css
 ln -sf ~/.themes/Material-Gnome/gtk-4.0/gtk-dark.css ~/.config/gtk-4.0/gtk-dark.css
 ```
 
+### Optional: Manager App
+
+If you prefer a GUI workflow, [Material GNOME Manager](https://github.com/AdityaHebballe/Material-Gnome-Manager) is a community GTK4/Libadwaita app that can fetch and update the theme, install it locally, apply color presets, generate Matugen palettes, and link GTK4/Libadwaita files automatically.
+
+On Arch Linux, it is also available from the AUR:
+
+```bash
+yay -S material-gnome-manager-git
+```
+
 ---
 
 ## 📦 Flatpak Application Support


### PR DESCRIPTION
Adds a short README mention for Material GNOME Manager, a community GTK4/Libadwaita app for managing this theme.

  The app can handle several manual setup steps from the README, including:

  - fetching and updating the theme
  - installing it locally
  - applying bundled color presets
  - generating Matugen palettes
  - linking GTK4/Libadwaita files into `~/.config/gtk-4.0`

  It also includes the AUR package name for Arch users.

  ## Link

  https://github.com/AdityaHebballe/Material-Gnome-Manager